### PR TITLE
MicrometerアダプタにHTTPリクエストの処理時間のメトリクスを追加

### DIFF
--- a/src/main/java/nablarch/fw/handler/MethodBinding.java
+++ b/src/main/java/nablarch/fw/handler/MethodBinding.java
@@ -23,6 +23,16 @@ import nablarch.fw.Result.NotFound;
  */
 public abstract class MethodBinding<TData, TResult>
 implements HandlerWrapper<TData, TResult> {
+    // ------------------------------------------------ constants
+    /**
+     * ディスパッチ先の {@link Class} オブジェクトをリクエストスコープに保存するときのキー名。
+     */
+    public static final String SCOPE_VAR_NAME_BOUND_CLASS = "nablarch_method_binding_bound_class";
+    /**
+     * ディスパッチ先の {@link Method} オブジェクトをリクエストスコープに保存するときのキー名。
+     */
+    public static final String SCOPE_VAR_NAME_BOUND_METHOD = "nablarch_method_binding_bound_method";
+
     // ------------------------------------------------ structure
     /** ディスパッチの対象となるオブジェクト */
     private final Object delegate;
@@ -100,6 +110,7 @@ implements HandlerWrapper<TData, TResult> {
             @SuppressWarnings("unchecked")
             public TResult handle(TData req, ExecutionContext ctx) {
                 try {
+                    saveBoundClassAndMethodToRequestScope(ctx, boundMethod.getDeclaringClass(), boundMethod);
                     return (TResult) boundMethod.invoke(delegate, req, ctx);
 
                 } catch (IllegalAccessException e) {
@@ -120,6 +131,17 @@ implements HandlerWrapper<TData, TResult> {
         };
         return Interceptor.Factory.wrap(handler, boundMethod.getAnnotations())
                                   .handle(req, ctx);
+    }
+
+    /**
+     * ディスパッチ先のクラスとメソッドをリクエストスコープに記録する。
+     * @param context コンテキスト
+     * @param clazz 委譲先のクラス
+     * @param method 委譲先のメソッド
+     */
+    protected void saveBoundClassAndMethodToRequestScope(ExecutionContext context, Class<?> clazz, Method method) {
+        context.setRequestScopedVar(SCOPE_VAR_NAME_BOUND_CLASS, clazz);
+        context.setRequestScopedVar(SCOPE_VAR_NAME_BOUND_METHOD, method);
     }
     
     /** {@inheritDoc} */

--- a/src/test/java/nablarch/fw/handler/DispatchHandlerTest.java
+++ b/src/test/java/nablarch/fw/handler/DispatchHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 import static org.hamcrest.Matchers.*;
@@ -172,6 +173,19 @@ public class DispatchHandlerTest {
 
         List<String> memory = OnMemoryLogWriter.getMessages("writer.memory");
         assertThat(memory, is(Matchers.<String>emptyIterable()));
+    }
+
+    @Test
+    public void testHandlerClassAndMethodAreSavedInRequestScope() throws Exception {
+        TestDispatchHandler sut = new TestDispatchHandler(TestHandler.class);
+        sut.handle("REQUEST", context);
+
+        Class<?> clazz = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS);
+        assertThat(clazz, is((Object)TestHandler.class));
+
+        Method method = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD);
+        Method handleMethod = TestHandler.class.getMethod("handle", Object.class, ExecutionContext.class);
+        assertThat(method, is(handleMethod));
     }
 
     public static class TestDispatchHandler extends DispatchHandler<String, String, TestDispatchHandler> {

--- a/src/test/java/nablarch/fw/handler/DispatchHandlerTest.java
+++ b/src/test/java/nablarch/fw/handler/DispatchHandlerTest.java
@@ -180,8 +180,8 @@ public class DispatchHandlerTest {
         TestDispatchHandler sut = new TestDispatchHandler(TestHandler.class);
         sut.handle("REQUEST", context);
 
-        Class<?> clazz = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS);
-        assertThat(clazz, is((Object)TestHandler.class));
+        Class<TestHandler> clazz = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS);
+        assertThat(clazz, sameInstance(TestHandler.class));
 
         Method method = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD);
         Method handleMethod = TestHandler.class.getMethod("handle", Object.class, ExecutionContext.class);

--- a/src/test/java/nablarch/fw/handler/DispatchHandlerTest.java
+++ b/src/test/java/nablarch/fw/handler/DispatchHandlerTest.java
@@ -1,0 +1,231 @@
+package nablarch.fw.handler;
+
+import nablarch.fw.*;
+import nablarch.test.support.log.app.OnMemoryLogWriter;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link DispatchHandler}の単体テスト。
+ *
+ * @author Tanaka Tomoyuki
+ */
+public class DispatchHandlerTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private ExecutionContext context = new ExecutionContext();
+
+    @Before
+    public void setup() {
+        OnMemoryLogWriter.clear();
+    }
+
+    @Test
+    public void testHandle() {
+        TestDispatchHandler sut = new TestDispatchHandler(TestHandler.class);
+
+        String returnValue = sut.handle("REQUEST", context);
+
+        assertThat(returnValue, is("TEST_HANDLER"));
+    }
+
+    @Test
+    public void testThrowsExceptionIfHandlerClassNotFound() {
+        DispatchHandler<String, String, ?> sut = new DispatchHandler<String, String, DispatchHandler<String, String, ?>>() {
+
+            @Override
+            protected Class<?> getHandlerClass(String input, ExecutionContext context) throws ClassNotFoundException {
+                throw new ClassNotFoundException("test class not found");
+            }
+        };
+
+        exception.expect(Result.NotFound.class);
+        exception.expectCause(is(Matchers.<Throwable>instanceOf(ClassNotFoundException.class)));
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testThrowsExceptionIfDelegateClassCouldNotInstantiate() {
+        TestDispatchHandler sut = new TestDispatchHandler(NoDefaultConstructor.class);
+
+        exception.expect(RuntimeException.class);
+        exception.expectCause(is(Matchers.<Throwable>instanceOf(InstantiationException.class)));
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testThrowsExceptionIfDelegateClassConstructorIsNotAccessible() {
+        TestDispatchHandler sut = new TestDispatchHandler(PrivateConstructor.class);
+
+        exception.expect(RuntimeException.class);
+        exception.expectCause(is(Matchers.<Throwable>instanceOf(IllegalAccessException.class)));
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testThrowsExceptionIfHandlerCloudNotBeCreated() {
+        TestDispatchHandler sut = new TestDispatchHandler(NotHandler.class);
+
+        exception.expect(Result.NotFound.class);
+        exception.expectMessage("Couldn't instantiate handler.: " + NotHandler.class.getName());
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testDelegateHandlerInsertTopOfHandlerQueueIfImmediateIsTrue() {
+        TestDispatchHandler sut = new TestDispatchHandler(TestHandler.class);
+        sut.setImmediate(true);
+
+        MockHandler fooHandler = new MockHandler("foo");
+        MockHandler barHandler = new MockHandler("bar");
+        context.addHandler(fooHandler);
+        context.addHandler(barHandler);
+
+        String returnValue = sut.handle("REQUEST", context);
+
+        assertThat(fooHandler.invoked, is(false));
+        assertThat(barHandler.invoked, is(false));
+
+        assertThat(returnValue, is("TEST_HANDLER"));
+    }
+
+    @Test
+    public void testDelegateHandlerInsertBottomOfHandlerQueueIfImmediateIsFalse() {
+        TestDispatchHandler sut = new TestDispatchHandler(TestHandler.class);
+        sut.setImmediate(false);
+
+        MockHandler fooHandler = new MockHandler("foo");
+        MockHandler barHandler = new MockHandler("bar");
+        context.addHandler(fooHandler);
+        context.addHandler(barHandler);
+
+        String returnValue = sut.handle("REQUEST", context);
+
+        assertThat(fooHandler.invoked, is(true));
+        assertThat(barHandler.invoked, is(false));
+
+        assertThat(returnValue, is("foo"));
+
+        assertThat(context.getHandlerQueue(), contains(
+            instanceOf(MockHandler.class),
+            instanceOf(TestHandler.class)
+        ));
+    }
+
+    @Test
+    public void testSetDelegateFactory() {
+        TestDispatchHandler sut = new TestDispatchHandler(TestHandler.class);
+        sut.setDelegateFactory(new DelegateFactory() {
+            @Override
+            public Object create(Class<?> clazz) {
+                return new TestHandler("CREATE_BY_CUSTOM_DELEGATE_FACTORY");
+            }
+        });
+
+        String returnValue = sut.handle("REQUEST", context);
+
+        assertThat(returnValue, is("CREATE_BY_CUSTOM_DELEGATE_FACTORY"));
+    }
+
+    @Test
+    public void testMethodBinderCreateNextHandlerIfDelegateIsNotHandlerAndContextHasMethodBinder() {
+        TestDispatchHandler sut = new TestDispatchHandler(NotHandler.class);
+        context.setMethodBinder(new MethodBinder<String, String>() {
+            @Override
+            public HandlerWrapper<String, String> bind(Object o) {
+                return new HandlerWrapper<String, String>() {
+                    @Override
+                    public List<Object> getDelegates(String s, ExecutionContext executionContext) {
+                        return null;
+                    }
+
+                    @Override
+                    public String handle(String s, ExecutionContext executionContext) {
+                        return "CUSTOM_METHOD_BINDER";
+                    }
+                };
+            }
+        });
+
+        String returnValue = sut.handle("REQUEST", context);
+
+        assertThat(returnValue, is("CUSTOM_METHOD_BINDER"));
+    }
+
+    @Test
+    public void testWriteDispatchingClassLogIsNoop() {
+        TestDispatchHandler sut = new TestDispatchHandler(TestHandler.class);
+        sut.writeDispatchingClassLog(null, null, null);
+
+        List<String> memory = OnMemoryLogWriter.getMessages("writer.memory");
+        assertThat(memory, is(Matchers.<String>emptyIterable()));
+    }
+
+    public static class TestDispatchHandler extends DispatchHandler<String, String, TestDispatchHandler> {
+        private final Class<?> handlerClass;
+
+        public TestDispatchHandler(Class<?> handlerClass) {
+            this.handlerClass = handlerClass;
+        }
+
+        @Override
+        protected Class<?> getHandlerClass(String input, ExecutionContext context) throws ClassNotFoundException {
+            return handlerClass;
+        }
+    }
+
+    public static class TestHandler implements Handler<String, String> {
+        private final String returnValue;
+
+        public TestHandler() {
+            this("TEST_HANDLER");
+        }
+
+        public TestHandler(String returnValue) {
+            this.returnValue = returnValue;
+        }
+
+        @Override
+        public String handle(String request, ExecutionContext context) {
+            return returnValue;
+        }
+    }
+
+    public static class NoDefaultConstructor {
+        public NoDefaultConstructor(String arg) {}
+    }
+
+    public static class PrivateConstructor {
+        private PrivateConstructor() {}
+    }
+
+    public static class NotHandler {}
+
+    public static class MockHandler implements Handler<String, String> {
+        private final String returnValue;
+        private boolean invoked;
+
+        public MockHandler(String returnValue) {
+            this.returnValue = returnValue;
+        }
+
+        @Override
+        public String handle(String s, ExecutionContext executionContext) {
+            invoked = true;
+            return returnValue;
+        }
+    }
+}

--- a/src/test/java/nablarch/fw/handler/MethodBindingTest.java
+++ b/src/test/java/nablarch/fw/handler/MethodBindingTest.java
@@ -1,0 +1,245 @@
+package nablarch.fw.handler;
+
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.Result;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * {@link MethodBinding}の単体テスト。
+ *
+ * @author Tanaka Tomoyuki
+ */
+public class MethodBindingTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private MockAction delegate = new MockAction("RETURN");
+    private ExecutionContext context = new ExecutionContext();
+
+    @Test
+    public void testDelegateMethod() {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate, "hello");
+
+        String returnValue = sut.handle("requestValue", context);
+
+        assertThat(delegate.request, is("requestValue"));
+        assertThat(delegate.context, is(sameInstance(context)));
+        assertThat(returnValue, is(delegate.returnValue));
+    }
+
+    @Test
+    public void testThrowsExceptionIfMethodNotFound() {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate, "notExist");
+
+        exception.expect(Result.NotFound.class);
+        exception.expectMessage("Couldn't find method to delegate.: REQUEST");
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testThrowsExceptionIfIllegalAccess() {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate, "privateMethod");
+
+        exception.expect(RuntimeException.class);
+        exception.expectCause(Matchers.<Throwable>instanceOf(IllegalAccessException.class));
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testRuntimeExceptionThrownByDelegateMethodIsRethrow() {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate, "throwsRuntimeException");
+
+        exception.expect(NullPointerException.class);
+        exception.expectMessage("test null");
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testErrorThrownByDelegateMethodIsRethrow() {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate, "throwsError");
+
+        exception.expect(StackOverflowError.class);
+        exception.expectMessage("test stackoverflow");
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testExceptionThrownByDelegateMethodIsThrownWrappedByRuntimeException() {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate, "throwsException");
+
+        exception.expect(RuntimeException.class);
+        exception.expectCause(Matchers.<Throwable>instanceOf(IOException.class));
+
+        sut.handle("REQUEST", context);
+    }
+
+    @Test
+    public void testGetDelegates() {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate);
+
+        List<Object> result = sut.getDelegates("nouse", context);
+
+        assertThat(result, contains((Object)delegate));
+    }
+
+    @Test
+    public void testGetHandleMethod() throws Exception {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate);
+
+        Method handleMethod = sut.getHandleMethod("HELLO");
+
+        Method helloMethod = MockAction.class.getMethod("hello", String.class, ExecutionContext.class);
+        assertThat(handleMethod, is(helloMethod));
+    }
+
+    @Test
+    public void testReturnNullIfHandleMethodIsNotFound() throws Exception {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate);
+
+        Method handleMethod = sut.getHandleMethod("notHandleMethod");
+
+        assertThat(handleMethod, is(nullValue()));
+    }
+
+    @Test
+    public void testHandleMethodOfAnonymousClassBecomeToAccessible() {
+        Object delegate = new Object() {
+            public String handle(String request, ExecutionContext context) {
+                return "anonymous class";
+            }
+        };
+
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate);
+
+        Method handleMethod = sut.getHandleMethod("handle");
+        assertThat(handleMethod.isAccessible(), is(true));
+    }
+
+    @Test
+    public void testStaticMethodIsNotHandleMethod() throws Exception {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate);
+
+        Method method = HandleMethodPatternTestAction.class.getMethod("staticMethod", String.class, ExecutionContext.class);
+
+        assertThat(sut.qualifiesAsHandler(method), is(false));
+    }
+
+    @Test
+    public void testPrivateMethodIsNotHandleMethod() throws Exception {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate);
+
+        Method method = HandleMethodPatternTestAction.class.getDeclaredMethod("privateMethod", String.class, ExecutionContext.class);
+
+        assertThat(sut.qualifiesAsHandler(method), is(false));
+    }
+
+    @Test
+    public void testMethodIsNotHandleMethodIfNumberOfArgumentsIsNotTwo() throws Exception {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate);
+
+        Method method = HandleMethodPatternTestAction.class.getMethod("threeArguments", String.class, ExecutionContext.class, int.class);
+
+        assertThat(sut.qualifiesAsHandler(method), is(false));
+    }
+
+    @Test
+    public void testMethodIsNotMethodHandleIfSecondArgumentIsNotExecutionContext() throws Exception {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate);
+
+        Method method = HandleMethodPatternTestAction.class.getMethod("notExecutionContext", String.class, int.class);
+
+        assertThat(sut.qualifiesAsHandler(method), is(false));
+    }
+
+    @Test
+    public void testAssertionErrorIfDelegateIsNull() {
+        exception.expect(AssertionError.class);
+        new TestMethodBinding(null, "nouse");
+    }
+
+    public static class TestMethodBinding extends MethodBinding<String, String> {
+        private final String methodName;
+
+        public TestMethodBinding(Object delegate) {
+            this(delegate, null);
+        }
+
+        public TestMethodBinding(Object delegate, String methodName) {
+            super(delegate);
+            this.methodName = methodName;
+        }
+
+        @Override
+        protected Method getMethodBoundTo(String s, ExecutionContext ctx) {
+            try {
+                return MockAction.class.getDeclaredMethod(methodName, String.class, ExecutionContext.class);
+            } catch (NoSuchMethodException e) {
+                return null;
+            }
+        }
+    }
+
+    public static class MockAction {
+        private final String returnValue;
+        private String request;
+        private ExecutionContext context;
+
+        public MockAction(String returnValue) {
+            this.returnValue = returnValue;
+        }
+
+        public String hello(String request, ExecutionContext context) {
+            this.request = request;
+            this.context = context;
+            return returnValue;
+        }
+
+        public void notHandleMethod() {}
+
+        private void privateMethod(String request, ExecutionContext context) {}
+
+        public String throwsRuntimeException(String request, ExecutionContext context) {
+            throw new NullPointerException("test null");
+        }
+
+        public String throwsError(String request, ExecutionContext context) {
+            throw new StackOverflowError("test stackoverflow");
+        }
+
+        public String throwsException(String request, ExecutionContext context) throws IOException {
+            throw new IOException("test io");
+        }
+    }
+
+    public static class HandleMethodPatternTestAction {
+        public static String staticMethod(String request, ExecutionContext context) {
+            return null;
+        }
+
+        private String privateMethod(String request, ExecutionContext context) {
+            return null;
+        }
+
+        public String threeArguments(String request, ExecutionContext context, int integer) {
+            return null;
+        }
+
+        public String notExecutionContext(String request, int integer) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/nablarch/fw/handler/MethodBindingTest.java
+++ b/src/test/java/nablarch/fw/handler/MethodBindingTest.java
@@ -171,6 +171,20 @@ public class MethodBindingTest {
         new TestMethodBinding(null, "nouse");
     }
 
+    @Test
+    public void testDelegateClassAndMethodAreSavedInRequestScope() throws Exception {
+        MethodBinding<String, String> sut = new TestMethodBinding(delegate, "hello");
+
+        sut.handle("REQUEST", context);
+
+        Class<?> clazz = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS);
+        assertThat(clazz, is((Object)delegate.getClass()));
+
+        Method method = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD);
+        Method helloMethod = delegate.getClass().getMethod("hello", String.class, ExecutionContext.class);
+        assertThat(method, is(helloMethod));
+    }
+
     public static class TestMethodBinding extends MethodBinding<String, String> {
         private final String methodName;
 


### PR DESCRIPTION
下記 Micrometer アダプタの機能追加で必要になる修正です。
https://github.com/nablarch/nablarch-micrometer-adaptor/pull/5

`MethodBinding`, `DispatchHandler` で、ディスパッチ先のアクションクラスの `Class` と `Method` をリクエストスコープに保存するようにする修正です。

`DispatchHandler` も修正しているのは、ディスパッチ先のクラスが `Handler` を実装している場合は `MethodBinding` を使わずにキャストしてそのまま実行するようになっているためです。

`MethodBinding`, `DispatchHandler` に単体テストクラスが無かったため、既存コードのテストケースも作成しています。